### PR TITLE
Modify 3D plugin to work with other content types

### DIFF
--- a/src/plugins/MiradorModelViewerPlugin/MiradorModelViewer.js
+++ b/src/plugins/MiradorModelViewerPlugin/MiradorModelViewer.js
@@ -1,108 +1,38 @@
 import React, { Component, lazy, Suspense } from 'react';
 import ModelViewer from '@google/model-viewer';
-import flattenDeep from 'lodash/flattenDeep';
-import flatten from 'lodash/flatten';
-
-const AudioViewer = lazy(() => import('mirador/dist/es/src/containers/AudioViewer'));
-const GalleryView = lazy(() => import('mirador/dist/es/src/containers/GalleryView'));
-const SelectCollection = lazy(() => import('mirador/dist/es/src/containers/SelectCollection'));
-const WindowViewer = lazy(() => import('mirador/dist/es/src/containers/WindowViewer'));
-const VideoViewer = lazy(() => import('mirador/dist/es/src/containers/VideoViewer'));
-
 
 class MiradorModelViewer extends Component {
-
-  get3DResources(canvas) {
-    if (canvas != undefined) {
-      const resources = flattenDeep([
-        canvas.getContent().map(i => i.getBody()),
-      ]);
-      return flatten(resources.filter((resource) => resource.getProperty('type') === 'Model'));
-    }
-    else {
-      return [];
-    }
-  }
-
-  renderViewer(){
-    
+  render3DViewer(){
     const {
-      audioResources, isCollection,
-      isFetching, videoResources, view, windowId,
+      threeDResources,
     } = this.props;
 
-    const models = this.get3DResources(this.props.canvas);
-    console.log(this.props);
-    if (isCollection) {
-      return (
-        <>
-          <SelectCollection
-            windowId={windowId}
-          />
-        </>
-      );
-    }
-    if (isFetching === false) {
-      if (view === 'gallery') {
-        return (
-          <GalleryView
-            windowId={windowId}
-          />
-        );
-      }
-      if (videoResources.length > 0) {
-        return (
-          <VideoViewer
-            windowId={windowId}
-          />
-        );
-      }
-      if (audioResources.length > 0) {
-        return (
-          <AudioViewer
-            windowId={windowId}
-          />
-        );
-      }
+    const styles = {
+      width: "100%",
+      height: "100%",
+      background: "black"
+    };
 
-      if (models.length > 0) {
-        const styles = {
-          width: "100%",
-          height: "100%",
-          background: "black"
-        };
-
-        return (
-          <model-viewer
-            style={{ background: styles.background, width: styles.width, height: styles.height }}
-            src={models[0].id}
-            alt={this.props.title}
-            auto-rotate camera-controls>
-          </model-viewer>
-        );
-      }
-
-      
-      return (
-        
-        <WindowViewer
-          windowId={windowId}
-        />
-      );
-    }
-
-    else {
-      return null;
-    }
-
+    return (
+      <model-viewer
+        style={{ background: styles.background, width: styles.width, height: styles.height }}
+        src={threeDResources[0].id}
+        alt={this.props.title}
+        auto-rotate camera-controls>
+      </model-viewer>
+    );
   }
 
   render() {
-    return(
-      <Suspense fallback={<div />}>
-          {this.renderViewer()}
-        </Suspense>
-  )
+    const { TargetComponent, targetProps, threeDResources } = this.props;
+    // Conditionally render new functionality when there is 3D content.
+    if (threeDResources && threeDResources.length > 0) {
+      return this.render3DViewer();
+    } else {
+      return (
+        <TargetComponent {...targetProps} />
+      )
+    }
   }
 }
-export default (MiradorModelViewer);
+export default MiradorModelViewer;

--- a/src/plugins/MiradorModelViewerPlugin/index.js
+++ b/src/plugins/MiradorModelViewerPlugin/index.js
@@ -1,22 +1,32 @@
 import React, { Component } from 'react';
 import ModelViewer from '@google/model-viewer';
 import {
-  getCurrentCanvas,getManifestTitle, getManifestoInstance, getVisibleCanvasAudioResources, getVisibleCanvasVideoResources, getWindow,getManifestStatus,getWindowViewType
+  getCurrentCanvas, getManifestoInstance,
 } from 'mirador/dist/es/src/state/selectors';
+import flattenDeep from 'lodash/flattenDeep';
+import flatten from 'lodash/flatten';
 
 import MiradorModelViewer from './MiradorModelViewer'
 
-const mapStateToProps = (state, { canvasId,windowId }) => {
+// Define this like a selector so that this content can be passed directly into the component as a prop
+function threeDResources(canvas) {
+  if (canvas != undefined) {
+    const resources = flattenDeep([
+      canvas.getContent().map(i => i.getBody()),
+    ]);
+    return flatten(resources.filter((resource) => resource.getProperty('type') === 'Model'));
+  }
+  else {
+    return [];
+  }
+}
+
+// Only add the necessary additional mapStateToProps
+const mapStateToProps = (state, { canvasId, windowId }) => {
   const manifestoInstance = getManifestoInstance(state, { windowId });
+  const canvas = getCurrentCanvas(state, { canvasId, windowId });
   return {
-    audioResources: getVisibleCanvasAudioResources(state, { windowId }) || [],
-    isCollection: manifestoInstance && manifestoInstance.isCollection(),
-    isCollectionDialogVisible: getWindow(state, { windowId }).collectionDialogOn,
-    videoResources: getVisibleCanvasVideoResources(state, { windowId }) || [],
-    isFetching:getManifestStatus(state, { windowId }).isFetching,
-    title: getManifestTitle(state, { canvasId, windowId }),
-    canvas: getCurrentCanvas(state, { canvasId, windowId }),
-    view: getWindowViewType(state, { windowId }),
+    threeDResources: threeDResources(canvas),
   };
 };
 


### PR DESCRIPTION
This aims to simplify the approach and not have to recreate the logic upstream.

While this will work fine, the seam I thought that was in `PrimaryWindow` doesn't work when multiple windows exist. I'm going to look to add some additional functionality in upstream Mirador to make plugins like this a little easier to create.